### PR TITLE
Delete board functionality

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -19,7 +19,7 @@ jobs:
           REACT_APP_MESSAGING_SENDER_ID: ${{ secrets.REACT_APP_MESSAGING_SENDER_ID }}
           REACT_APP_APP_ID: ${{ secrets.REACT_APP_APP_ID }}
           REACT_APP_MEASUREMENT_ID: ${{ secrets.REACT_APP_MEASUREMENT_ID }}
-          REACT_APP_SERVICE_URL: ${{ secrets.REACT_APP_SERVICE_URL }}
+          REACT_APP_SERVICE_URL: ${{ secrets.REACT_APP_SERVICE_URL_DEV }}
           REACT_APP_UNSPLASH_ACCESS_KEY: ${{ secrets.REACT_APP_UNSPLASH_ACCESS_KEY }}
           CI: ${{ vars.CI }}
       - uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 build
 coverage
 README.md
+.serverless

--- a/client/src/api/Board.js
+++ b/client/src/api/Board.js
@@ -109,13 +109,16 @@ export const RemoveUser = (body) =>
 export const RemoveBoard = (body) =>
   new Promise(async (resolve, reject) => {
     try {
-      const response = await fetch(process.env.REACT_APP_SERVICE_URL + "", {
-        method: "DELETE",
-        headers: new Headers({
-          "Content-type": "application/json; charset=UTF-8",
-        }),
-        body: JSON.stringify(body),
-      });
+      const response = await fetch(
+        process.env.REACT_APP_SERVICE_URL + "/board",
+        {
+          method: "DELETE",
+          headers: new Headers({
+            "Content-type": "application/json; charset=UTF-8",
+          }),
+          body: JSON.stringify(body),
+        },
+      );
 
       resolve(response.json());
     } catch (err) {

--- a/client/src/components/BoardDrawer/index.js
+++ b/client/src/components/BoardDrawer/index.js
@@ -21,9 +21,13 @@ import { drawerStyles } from "./styles";
 const BoardDrawer = ({ board, admin }) => {
   let history = useHistory();
   const classes = drawerStyles();
-  const { drawerOpen, changeDrawerVisibility, setRenderedBoard } =
-    useContext(UIContext);
-  const { boards, setBoards } = useContext(UserContext);
+  const {
+    drawerOpen,
+    changeDrawerVisibility,
+    setRenderedBoard,
+    setOpenBackdrop,
+  } = useContext(UIContext);
+  const { userData, boards, setBoards } = useContext(UserContext);
 
   const [displayDescriptionEditArea, setDisplayDescriptionEditArea] =
     useState(false);
@@ -52,19 +56,6 @@ const BoardDrawer = ({ board, admin }) => {
 
   const closeRemoveDialog = () => {
     setDisplayRemoveDialog(false);
-  };
-
-  const handleBoardDelete = () => {
-    BoardHelpers.HandleRemovingBoard(board.id)
-      .then(() => {
-        const newBoards = boards.filter((current) => current.id !== board.id);
-        history.push("/boards");
-        setBoards(newBoards);
-        changeDrawerVisibility("set", false);
-      })
-      .catch((err) => {
-        console.error(err);
-      });
   };
 
   const editDescription = (description) => {
@@ -101,25 +92,44 @@ const BoardDrawer = ({ board, admin }) => {
   const removeUser = (user) => {
     const uid = user.uid;
     const users = board.users.filter((user) => user.uid !== uid);
-    const userData = board.userData.filter((user) => user.uid !== uid);
+    const filteredUserData = board.userData.filter((user) => user.uid !== uid);
 
     setRenderedBoard({
       ...board,
       users: users,
-      userData: userData,
+      userData: filteredUserData,
     });
     BoardHelpers.HandleBoardPropertyUpdate(board.id, "users", users).then(
       () => {
         for (let i = 0; i < boards.length; i++) {
           if (boards[i].id === board.id) {
             boards[i].users = users;
-            boards[i].userData = userData;
+            boards[i].userData = filteredUserData;
             setBoards(boards);
           }
         }
       },
     );
     BoardHelpers.HandleRemovingUser(board.id, uid);
+  };
+
+  const deleteBoard = async () => {
+    if (!admin) return;
+    setOpenBackdrop(true);
+
+    // deletes the board and removes board from each user
+    await Promise.all([
+      BoardHelpers.HandleRemovingBoard(board.id, userData.uid),
+      ...board.users.map((currentUser) =>
+        BoardHelpers.HandleRemovingUser(board.id, currentUser.uid),
+      ),
+    ]).catch((err) => console.error(err));
+
+    const newBoards = boards.filter((current) => current.id !== board.id);
+    history.push("/boards");
+    setBoards(newBoards);
+    setOpenBackdrop(false);
+    changeDrawerVisibility("set", false);
   };
 
   return (

--- a/client/src/components/BoardDrawer/index.js
+++ b/client/src/components/BoardDrawer/index.js
@@ -440,38 +440,42 @@ const BoardDrawer = ({ board, admin }) => {
               }
             })}
           {/* DELETE BOARD */}
-          {confirmDelete ? (
-            <Grid>
-              <Typography variant="subtitle1" component="p">
-                Are you sure?
-              </Typography>
-              <ButtonGroup>
-                <Button
-                  onClick={handleBoardDelete}
-                  className={classes.deleteButton}
-                >
-                  Yes
-                </Button>
-                <Button
-                  variant="contained"
-                  color="primary"
-                  style={{ margin: "10px 0" }}
-                  onClick={() => setConfirmDelete(false)}
-                >
-                  No
-                </Button>
-              </ButtonGroup>
-            </Grid>
-          ) : (
-            <Button
-              variant="contained"
-              className={classes.deleteButton}
-              startIcon={<Delete />}
-              onClick={() => setConfirmDelete(true)}
-            >
-              Delete Board
-            </Button>
-          )}
+          {admin ? (
+            confirmDelete ? (
+              <Grid>
+                <Typography variant="subtitle1" component="p">
+                  Are you sure?
+                </Typography>
+                <ButtonGroup>
+                  <Button
+                    onClick={deleteBoard}
+                    className={classes.deleteButton}
+                    variant="contained"
+                    color="secondary"
+                  >
+                    Yes
+                  </Button>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    style={{ margin: "10px 0" }}
+                    onClick={() => setConfirmDelete(false)}
+                  >
+                    No
+                  </Button>
+                </ButtonGroup>
+              </Grid>
+            ) : (
+              <Button
+                variant="contained"
+                className={classes.deleteButton}
+                startIcon={<Delete />}
+                onClick={() => setConfirmDelete(true)}
+              >
+                Delete Board
+              </Button>
+            )
+          ) : null}
         </Grid>
       )}
     </Drawer>

--- a/client/src/helpers/Board.js
+++ b/client/src/helpers/Board.js
@@ -234,6 +234,7 @@ const HandleBoardPropertyUpdate = (boardId, property, data) =>
     }
   });
 
+// removes board from user data
 const HandleRemovingUser = (boardId, userId) =>
   new Promise((resolve, reject) => {
     RemoveUser({ boardId: boardId, userId: userId })
@@ -245,9 +246,9 @@ const HandleRemovingUser = (boardId, userId) =>
       });
   });
 
-const HandleRemovingBoard = (boardId) =>
+const HandleRemovingBoard = (boardId, userId) =>
   new Promise((resolve, reject) => {
-    RemoveBoard({ boardId })
+    RemoveBoard({ boardId, userId })
       .then((response) => {
         response.ok ? resolve(response) : reject(response);
       })

--- a/service/.gitignore
+++ b/service/.gitignore
@@ -3,6 +3,8 @@ node_modules
 jspm_packages
 
 # Serverless directories
-.serverless
+s_*
 .env
+.serverless
 firebaseConfig.json
+serverless_sdk

--- a/service/handlers/board.js
+++ b/service/handlers/board.js
@@ -372,6 +372,7 @@ module.exports.delete = async (event) =>
         body: JSON.stringify({
           statusCode: 200,
           deletedBoard,
+          ok: true,
         }),
       };
 

--- a/service/handlers/board.js
+++ b/service/handlers/board.js
@@ -231,7 +231,7 @@ module.exports.users = async (event) => {
 
 module.exports.boards = async (event) => {
   const promise = new Promise(async (resolve, reject) => {
-    const boardList = JSON.parse(event.body).boardList;
+    const boardList = JSON.parse(event.body)?.boardList || false;
     if (boardList !== undefined && boardList.length > 0) {
       const boardData = await returnUserRelatedBoards(boardList);
       try {

--- a/service/handlers/board.js
+++ b/service/handlers/board.js
@@ -5,6 +5,7 @@ const {
   returnUserRelatedBoards,
   updateBoardProperty,
   removeBoardFromUser,
+  deleteBoard,
 } = require("../src/boards");
 
 module.exports.create = async (event) => {
@@ -336,3 +337,58 @@ module.exports.removeUser = async (event) => {
   });
   return promise;
 };
+
+module.exports.delete = async (event) =>
+  new Promise(async (resolve, reject) => {
+    try {
+      const { boardId, userId } = JSON.parse(event.body) || false;
+
+      if (!boardId || !userId) {
+        return reject({
+          statusCode: 400,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Credentials": true,
+          },
+          body: JSON.stringify({
+            statusCode: 400,
+            message: "Incorrect body",
+          }),
+        });
+      }
+
+      const deletedBoard = await deleteBoard(boardId, userId);
+
+      if (!deletedBoard) throw "No response";
+
+      const response = {
+        statusCode: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Credentials": true,
+        },
+        body: JSON.stringify({
+          statusCode: 200,
+          deletedBoard,
+        }),
+      };
+
+      resolve(response);
+    } catch (err) {
+      const response = {
+        statusCode: 500,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Credentials": true,
+        },
+        body: JSON.stringify({
+          statusCode: 500,
+          error: err.message || err,
+        }),
+      };
+      reject(response);
+    }
+  });

--- a/service/serverless.yml
+++ b/service/serverless.yml
@@ -53,6 +53,13 @@ functions:
           path: board
           method: put
           cors: true
+  removeBoard:
+    handler: handlers/board.delete
+    events:
+      - http:
+          path: board
+          method: delete
+          cors: true
   removeUser:
     handler: handlers/board.removeUser
     events:

--- a/service/src/boards.js
+++ b/service/src/boards.js
@@ -75,30 +75,17 @@ const linkUsersAndBoard = (users, boardId) =>
 const returnUserRelatedBoards = (boards) =>
   new Promise(async (resolve, reject) => {
     try {
-      const response = new Promise((resolve, reject) => {
-        const data = [];
-
-        boards.forEach((val, index) => {
+      const response = Promise.all(
+        boards.map(async (val) => {
           // val here should be unique id of a board
           const ref = db.ref(`/boards/${val}`);
-          ref.once("value", (snapshot) => {
-            const value = snapshot.val();
-            if (value !== undefined && value !== null) {
-              returnBoardRelatedUsers(value.users) // we are also returning users' data related to board
-                .then((response) => {
-                  value.userData = response;
-                  data.push(value);
-                })
-                .then(() => {
-                  // resolve promise if iterating last item of array
-                  if (index === boards.length - 1) resolve(data);
-                });
-            } else {
-              if (index === boards.length - 1) resolve(data);
-            }
-          });
-        });
-      });
+          const userBoard = (await ref.once("value")).val();
+          // we are also returning users' data related to board
+          const users = await returnBoardRelatedUsers(userBoard.users);
+          userBoard.userData = users;
+          return userBoard;
+        }),
+      );
 
       resolve(await response);
     } catch (err) {

--- a/service/src/boards.js
+++ b/service/src/boards.js
@@ -216,6 +216,23 @@ const removeBoardFromUser = (boardId, userId) =>
       }
     });
   });
+
+const deleteBoard = (boardId, userId) =>
+  new Promise(async (resolve, reject) => {
+    const ref = db.ref(`/boards/${boardId}`);
+
+    ref.once("value", (snapshot) => {
+      const value = snapshot.val();
+
+      if (!value || value.admin.uid !== userId)
+        return reject("board delete failed");
+
+      ref.remove((error) => {
+        error ? reject(error) : resolve(true);
+      });
+    });
+  });
+
 module.exports = {
   createNewBoard,
   returnUserRelatedBoards,
@@ -223,4 +240,5 @@ module.exports = {
   inviteUser,
   updateBoardProperty,
   removeBoardFromUser,
+  deleteBoard,
 };


### PR DESCRIPTION
### Added functionality to delete boards
- delete board route added
- delete board lambda added
- client remove board api updated
- hide delete button if not admin of board

### Refactored returnUserRelatedBoards - 9af763dc1c48c7090f15f3d28cfb1b07f0186f54
Due to race conditions when one board takes longer to load while looking through the .map it can return with missing data. Refactored so will wait until each parallel running board data retrieving finishes before resolving. 

### Refactored Auth - 40fc5ee77d8c3b267953f27acfb265e05b3861d7
For faster loading, removed whitelist checking on login. Won't be necessary due to signup deleting account already. Also moved the deletion of account out of whitelist function to createNewUser function for better and clearer separation of tasks. 

### Workflow PR
Workflow for PRs creating temp hosting now uses dev service url